### PR TITLE
removed python transformer

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,7 +7,3 @@ enabled = true
 [[transformers]]
 name = "standardjs"
 enabled = true
-
-[[transformers]]
-name = "autopep8"
-enabled = true


### PR DESCRIPTION
Removed python transformer because by default it wraps code to 79