### PR TITLE
workaroud db conn closed by admin

### DIFF
--- a/chsystem/database/database.py
+++ b/chsystem/database/database.py
@@ -42,7 +42,7 @@ class Database:
             self.db_uri = uri if uri is not None else self.db_uri
             self.db_url = url if url is not None else self.db_url
 
-        if self.conn is None:
+        if self.conn is None or force:
             self.conn = psycopg2.connect(self.db_uri)
             self.cur = self.conn.cursor()
             self.cur.execute('SELECT version()')

--- a/chsystem/discord/discordBot.py
+++ b/chsystem/discord/discordBot.py
@@ -62,6 +62,7 @@ class DiscordBot(discord.Client):
         except StopIteration:
             logger.error('StopIteration', extra=extra_log)
             self.cmds = get_chain_commands().send
+            clan_discord_db.update_url(force=True)
             return
 
         if msg_to_send['msg'] is not None:


### PR DESCRIPTION
when the connection is closed by the admin, an expection will be raised and that will raise StopIteration in the commands. Stop iteration is captured and there a new connection will be made. This is a workaround until the pool connection is implemeted